### PR TITLE
Fix array sanitization in logger

### DIFF
--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -27,8 +27,12 @@ function sanitizeLogData(obj, depth = 0, maxDepth = 5) {
     return sanitized;
   }
   
-  if (typeof obj !== 'object' || Array.isArray(obj)) return obj;
-  
+  if (Array.isArray(obj)) {
+    return obj.map(item => sanitizeLogData(item, depth + 1, maxDepth));
+  }
+
+  if (typeof obj !== 'object') return obj;
+
   const sanitized = {};
   Object.keys(obj).forEach(key => {
     const lowerKey = key.toLowerCase();


### PR DESCRIPTION
## Summary
- sanitize arrays in log entries to remove sensitive data

## Testing
- `JWT_SECRET=test JWT_REFRESH_SECRET=testref npm test --prefix backend` *(fails: The client is closed)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2085ca8832ebcba9d33733509bf