### PR TITLE
docs: pluralize Voraussetzungen heading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ cd frontend && npm run dev
 
 Nach wenigen Sekunden ist die Anwendung unter http://localhost:5173 erreichbar und kommuniziert mit dem Backend auf Port 3001.
 
-## Voraussetzung
+## Voraussetzungen
 
 - Node.js >=16
 - npm oder Yarn


### PR DESCRIPTION
## Summary
- fix README heading to use correct German plural

## Testing
- `npm test` *(fails: no package.json)*
- `cd backend && npm test` *(fails: JWT secrets must be configured in environment variables)*
- `cd frontend && npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc377193c832e830511080f4c760a