### PR TITLE
test: add cleanup expired sessions test

### DIFF
--- a/backend/test/simple-upload-test.js
+++ b/backend/test/simple-upload-test.js
@@ -1,24 +1,74 @@
+import { expect } from 'chai';
 import chunkedUploadController from '../controllers/chunkedUploadController.js';
 import cacheService from '../services/cacheService.js';
 
-// Mock cache service if not available
-if (!cacheService.keys) {
-  console.log('Adding mock keys method to cache service for testing');
-  cacheService.keys = async (pattern) => {
-    console.log(`Mock keys called with pattern: ${pattern}`);
-    return [];
-  };
-}
+describe('cleanupExpiredSessions', () => {
+  let originalKeys;
+  let originalGet;
+  let originalDelete;
+  let originalCleanup;
 
-console.log('✓ Chunked upload controller imported successfully');
-console.log('✓ Cache service methods available:', Object.getOwnPropertyNames(Object.getPrototypeOf(cacheService)));
+  beforeEach(() => {
+    // Save original implementations to restore after each test
+    originalKeys = cacheService.keys;
+    originalGet = cacheService.get;
+    originalDelete = cacheService.delete;
+    originalCleanup = chunkedUploadController.cleanupUploadSession;
+  });
 
-// Test cleanup method
-try {
-  const result = await chunkedUploadController.cleanupExpiredSessions();
-  console.log('✓ Cleanup method executed successfully, cleaned:', result);
-} catch (error) {
-  console.log('✗ Cleanup method failed:', error.message);
-}
+  afterEach(() => {
+    // Restore original implementations
+    cacheService.keys = originalKeys;
+    cacheService.get = originalGet;
+    cacheService.delete = originalDelete;
+    chunkedUploadController.cleanupUploadSession = originalCleanup;
+  });
 
-console.log('✓ Basic functionality test completed');
+  it('removes expired sessions and returns cleaned count', async () => {
+    const keysCalledWith = [];
+    const getCalls = [];
+    const deleteCalls = [];
+    const cleanupCalls = [];
+
+    // Mock cache service methods
+    cacheService.keys = async (pattern) => {
+      keysCalledWith.push(pattern);
+      return ['upload_session:1', 'upload_session:2'];
+    };
+
+    const now = Date.now();
+    const sessions = {
+      'upload_session:1': {
+        lastActivity: new Date(now - 25 * 60 * 60 * 1000).toISOString()
+      },
+      'upload_session:2': {
+        lastActivity: new Date(now - 60 * 60 * 1000).toISOString()
+      }
+    };
+
+    cacheService.get = async (key) => {
+      getCalls.push(key);
+      return sessions[key];
+    };
+
+    cacheService.delete = async (key) => {
+      deleteCalls.push(key);
+      return true;
+    };
+
+    // Mock cleanup of individual session
+    chunkedUploadController.cleanupUploadSession = async (session) => {
+      cleanupCalls.push(session);
+    };
+
+    const cleaned = await chunkedUploadController.cleanupExpiredSessions();
+
+    expect(cleaned).to.equal(1);
+    expect(keysCalledWith).to.deep.equal(['upload_session:*']);
+    expect(getCalls).to.deep.equal(['upload_session:1', 'upload_session:2']);
+    expect(deleteCalls).to.deep.equal(['upload_session:1']);
+    expect(cleanupCalls).to.have.lengthOf(1);
+    expect(cleanupCalls[0]).to.deep.equal(sessions['upload_session:1']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- rewrite simple upload test into a Mocha/Chai suite
- assert cacheService mock behavior and cleanupExpiredSessions outcome
- drop debug logging

## Testing
- `npm test` *(fails: JWT secrets must be configured in environment variables)*
- `npx mocha test/simple-upload-test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc39df4d4832e87c6d3b99885d627