### PR TITLE
Remove unused upload concurrency setting

### DIFF
--- a/CHUNKED_UPLOAD_SYSTEM.md
+++ b/CHUNKED_UPLOAD_SYSTEM.md
@@ -63,13 +63,11 @@ frontend/src/components/FileManager/FolderScanModal.vue     # Scan progress
 - **Reduced Chunk Size**: 2MB chunks (down from 5MB)
 - **Small Stream Buffers**: 16KB buffers to minimize memory usage
 - **Garbage Collection**: Forced GC every 10 chunks during finalization
-- **Limited Concurrency**: Max 3 concurrent uploads by default
 
 ### Configuration
 ```bash
 # Environment Variables
 UPLOAD_CHUNK_SIZE=2097152        # 2MB chunks
-MAX_CONCURRENT_UPLOADS=2         # Limit concurrent uploads
 MAX_UPLOAD_FILE_SIZE=53687091200 # 50GB max file size
 UPLOAD_SESSION_TTL=86400         # 24 hour session TTL
 
@@ -186,7 +184,6 @@ node test/simple-upload-test.js
 
 ### High Memory Usage
 - Ensure `UPLOAD_CHUNK_SIZE=2097152` (2MB)
-- Set `MAX_CONCURRENT_UPLOADS=2` or lower
 - Use Node.js flags: `--max-old-space-size=4096 --expose-gc`
 
 ### Cache Service Errors

--- a/UPLOAD_SYSTEM_READY.md
+++ b/UPLOAD_SYSTEM_READY.md
@@ -95,7 +95,6 @@ GET    /api/chunked-upload/active         # List active uploads
 ### Environment Variables:
 ```env
 UPLOAD_CHUNK_SIZE=2097152        # 2MB chunks
-MAX_CONCURRENT_UPLOADS=3         # Limit concurrent uploads
 MAX_UPLOAD_FILE_SIZE=53687091200 # 50GB max file size
 UPLOAD_SESSION_TTL=86400         # 24 hour session TTL
 ```

--- a/backend/controllers/chunkedUploadController.js
+++ b/backend/controllers/chunkedUploadController.js
@@ -8,7 +8,6 @@ import crypto from 'crypto';
 
 const CHUNK_SIZE = parseInt(process.env.UPLOAD_CHUNK_SIZE) || (2 * 1024 * 1024); // 2MB chunks (reduced for better memory usage)
 const UPLOAD_SESSION_TTL = parseInt(process.env.UPLOAD_SESSION_TTL) || (24 * 60 * 60); // 24 hours
-const MAX_CONCURRENT_UPLOADS = parseInt(process.env.MAX_CONCURRENT_UPLOADS) || 3; // eslint-disable-line no-unused-vars
 const MAX_FILE_SIZE = parseInt(process.env.MAX_UPLOAD_FILE_SIZE) || (50 * 1024 * 1024 * 1024); // 50GB
 
 const CACHE_PREFIX = `${process.env.CACHE_PREFIX || 'weppix'}:`;


### PR DESCRIPTION
## Summary
- drop MAX_CONCURRENT_UPLOADS constant from chunked upload controller
- update chunked upload docs to reflect removal

## Testing
- `npm test` *(fails: JWT secrets must be configured in environment variables)*
- `npm run lint` *(fails: 32 errors, 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68acc90360e8832e9153e5dcd4ab282d